### PR TITLE
made CV link actually work

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
         <a href="http://cnel.ufl.edu/people/people.php?name=eder" rel="me">publications</a>
       </li>
       <li>
-        <a href="https://github.com/EderSantana/edersantana.github.io/raw/master/files/eder_cv.pdf" rel="me">cv</a>
+        <a href="https://docs.google.com/viewer?url=https://github.com/EderSantana/edersantana.github.io/raw/master/eder_cv.pdf" rel="me">cv</a>
       </li>
       <li>
         <a href="https://edersantana.github.io/blog.html" rel="me">blog</a>


### PR DESCRIPTION
Original path was 404ing; changed "/raw/master/files/eder_cv.pdf" to "/raw/master/eder_cv.pdf".

Then, so that the PDF renders in the browser, added docs.google.com/viewer?url=
(source: http://webapps.stackexchange.com/questions/48061/can-i-trick-github-into-displaying-the-pdf-in-the-browser-instead-of-downloading)
